### PR TITLE
fix(prisma): add missing migration so a fresh setup matches schema.prisma

### DIFF
--- a/prisma/migrations/20260626004052_sync_schema_drift/migration.sql
+++ b/prisma/migrations/20260626004052_sync_schema_drift/migration.sql
@@ -1,0 +1,102 @@
+-- AlterTable
+ALTER TABLE "Hearing" ADD COLUMN     "address" TEXT,
+ADD COLUMN     "contact" TEXT;
+
+-- CreateTable
+CREATE TABLE "PreservationCase" (
+    "id" TEXT NOT NULL,
+    "matterId" TEXT,
+    "type" "PreservationType" NOT NULL,
+    "status" "PreservationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "court" TEXT,
+    "rulingNumber" TEXT,
+    "guaranteeType" "GuaranteeType",
+    "appliedAt" TIMESTAMP(3),
+    "note" TEXT,
+    "ownerId" TEXT,
+    "remindDays" INTEGER[] DEFAULT ARRAY[30, 15, 7, 3, 1]::INTEGER[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PreservationCase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PreservationTarget" (
+    "id" TEXT NOT NULL,
+    "caseId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PreservationTarget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PreservationProperty" (
+    "id" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "propertyType" "PropertyType" NOT NULL,
+    "propertyDetail" TEXT,
+    "amount" DECIMAL(18,2),
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "expiryDate" TIMESTAMP(3) NOT NULL,
+    "status" "PreservationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PreservationProperty_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PreservationPropertyRenewal" (
+    "id" TEXT NOT NULL,
+    "propertyId" TEXT NOT NULL,
+    "renewedAt" TIMESTAMP(3) NOT NULL,
+    "oldExpiryDate" TIMESTAMP(3) NOT NULL,
+    "newExpiryDate" TIMESTAMP(3) NOT NULL,
+    "renewalDuration" INTEGER NOT NULL,
+    "note" TEXT,
+    "performedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PreservationPropertyRenewal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PreservationCase_matterId_idx" ON "PreservationCase"("matterId");
+
+-- CreateIndex
+CREATE INDEX "PreservationCase_status_idx" ON "PreservationCase"("status");
+
+-- CreateIndex
+CREATE INDEX "PreservationTarget_caseId_idx" ON "PreservationTarget"("caseId");
+
+-- CreateIndex
+CREATE INDEX "PreservationProperty_targetId_idx" ON "PreservationProperty"("targetId");
+
+-- CreateIndex
+CREATE INDEX "PreservationProperty_status_expiryDate_idx" ON "PreservationProperty"("status", "expiryDate");
+
+-- CreateIndex
+CREATE INDEX "PreservationPropertyRenewal_propertyId_idx" ON "PreservationPropertyRenewal"("propertyId");
+
+-- AddForeignKey
+ALTER TABLE "PreservationCase" ADD CONSTRAINT "PreservationCase_matterId_fkey" FOREIGN KEY ("matterId") REFERENCES "Matter"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreservationCase" ADD CONSTRAINT "PreservationCase_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreservationTarget" ADD CONSTRAINT "PreservationTarget_caseId_fkey" FOREIGN KEY ("caseId") REFERENCES "PreservationCase"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreservationProperty" ADD CONSTRAINT "PreservationProperty_targetId_fkey" FOREIGN KEY ("targetId") REFERENCES "PreservationTarget"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreservationPropertyRenewal" ADD CONSTRAINT "PreservationPropertyRenewal_propertyId_fkey" FOREIGN KEY ("propertyId") REFERENCES "PreservationProperty"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreservationPropertyRenewal" ADD CONSTRAINT "PreservationPropertyRenewal_performedById_fkey" FOREIGN KEY ("performedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Problem

On a clean setup (`prisma migrate dev` + `prisma db seed` + `npm run dev`), the app crashes immediately on the dashboard:

```
Runtime PrismaClientKnownRequestError
Invalid `prisma.hearing.findMany()` invocation ...
The column `Hearing.address` does not exist in the current database.
  at getDashboardSchedule (src/server/dashboard/actions.ts:235)
```

Root cause: the checked-in `prisma/migrations` have drifted behind `prisma/schema.prisma`. `prisma migrate status` reports "up to date" (all 40 migration files apply), but the resulting database is missing objects that the schema declares, so any query touching them fails.

Reproducible from a fresh clone of `main`.

## Drift captured by this migration

- `Hearing.address`, `Hearing.contact` columns (breaks the dashboard schedule on first load)
- `Preservation*` tables — `PreservationCase`, `PreservationTarget`, `PreservationProperty`, `PreservationPropertyRenewal` — plus their indexes and foreign keys (breaks the preservation module)

## Fix

Generated with `prisma migrate dev --name sync_schema_drift`, so the committed migrations once again fully reproduce `schema.prisma`. No schema changes — this only adds the migration that should have accompanied those earlier schema edits.

## Verification

- `prisma migrate dev` + `db seed` on a clean DB → no drift
- Dashboard loads; `hearing.findMany` now selects `address`/`contact` cleanly
- `prisma migrate status` → in sync

## Suggested follow-up (not in this PR)

Add a CI check that fails when `schema.prisma` and `prisma/migrations` diverge (e.g. `prisma migrate diff --from-migrations ... --to-schema-datamodel ... --exit-code`) to prevent this class of regression.